### PR TITLE
Feature/PF-229-breadcrumbs

### DIFF
--- a/src/components/BreadcrumbsComponent/BreadcrumbsComponent.jsx
+++ b/src/components/BreadcrumbsComponent/BreadcrumbsComponent.jsx
@@ -1,0 +1,59 @@
+import {
+  Breadcrumbs, Link, Typography
+} from '@mui/material'
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+
+const breadcrumbsTypographyStyles = {
+  fontSize: '24px',
+  fontWeight: 400,
+  letterSpacing: '0.25px',
+  color: '#212121'
+};
+
+export const BreadcrumbsComponent = ({
+  prefix, title, subtitle, titleLink
+}) => {
+  return (
+    <Breadcrumbs
+      separator={
+        <NavigateNextIcon 
+          fontSize='large' 
+          sx={{ 
+            color:'#757575'
+          }}
+        /> 
+      }
+      aria-label='breadcrumb'
+    >
+      {prefix && (
+        <Typography
+          sx={breadcrumbsTypographyStyles}
+        >
+          {prefix}
+        </Typography>
+      )}
+      {subtitle ? (
+        <Link
+          underline='hover'
+          href={titleLink}
+          sx={breadcrumbsTypographyStyles}
+        >
+          {title}
+        </Link>
+      ) : (
+        <Typography
+          sx={breadcrumbsTypographyStyles}
+        >
+          {title}
+        </Typography>
+      )}
+      {subtitle && (
+        <Typography
+          sx={breadcrumbsTypographyStyles}
+        >
+          {subtitle}
+        </Typography>
+      )}
+    </Breadcrumbs>
+  )
+}

--- a/src/components/BreadcrumbsComponent/index.js
+++ b/src/components/BreadcrumbsComponent/index.js
@@ -1,0 +1,3 @@
+export {
+  BreadcrumbsComponent 
+} from './BreadcrumbsComponent'

--- a/src/components/FilterSideComponent/FilterSideComponent.jsx
+++ b/src/components/FilterSideComponent/FilterSideComponent.jsx
@@ -1,9 +1,12 @@
 import {
   Box, Button, Divider, Typography 
 } from '@mui/material';
+import {
+  BreadcrumbsComponent 
+} from '../../components/BreadcrumbsComponent';
 
 export const FilterSideComponent = ({
-  title, component 
+  title, component, prefix, subtitle, titleLink
 }) => {
   return (
     <Box
@@ -59,16 +62,12 @@ export const FilterSideComponent = ({
             padding: '16px 32px',
           }}
         >
-          <Typography
-            sx={{
-              fontSize: '34px',
-              fontWeight: 400,
-              letterSpacing: '0.25px',
-              textAlign: 'left',
-            }}
-          >
-            {title}
-          </Typography>
+          <BreadcrumbsComponent
+            prefix={prefix}
+            title={title}
+            subtitle={subtitle}
+            titleLink={titleLink}
+          />
         </Box>
         <Divider />
         {component()}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,6 +24,7 @@ import CreateAreaPage from './pages/CreateArea/CreateAreaPage.jsx';
 import HomePage from './pages/Home/HomePage.jsx';
 import RecommendationsPage from './pages/Recomendaciones/RecommendationsPage.jsx';
 import RoutesPage from './pages/Routes/RoutesPage.jsx';
+import RouteDetailPage from './pages/Routes/RouteDetailPage.jsx';
 import LoginPage from './pages/Login/LoginPage.jsx';
 import {
   ReportPage 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,7 +24,6 @@ import CreateAreaPage from './pages/CreateArea/CreateAreaPage.jsx';
 import HomePage from './pages/Home/HomePage.jsx';
 import RecommendationsPage from './pages/Recomendaciones/RecommendationsPage.jsx';
 import RoutesPage from './pages/Routes/RoutesPage.jsx';
-import RouteDetailPage from './pages/Routes/RouteDetailPage.jsx';
 import LoginPage from './pages/Login/LoginPage.jsx';
 import {
   ReportPage 

--- a/src/pages/Area/AreaPage.jsx
+++ b/src/pages/Area/AreaPage.jsx
@@ -5,6 +5,9 @@ import AddIcon from '@mui/icons-material/Add';
 import {
   APIProvider, Map 
 } from '@vis.gl/react-google-maps';
+import {
+  BreadcrumbsComponent 
+} from '../../components/BreadcrumbsComponent';
 
 const AreaPage = () => {
   const position = {
@@ -24,18 +27,14 @@ const AreaPage = () => {
     >
       <Box
         sx={{
-          padding: '16px 64px 14px',
+          width: '100%',
+          padding: '16px 32px',
         }}
       >
-        <Typography
-          sx={{
-            fontSize: '34px',
-            fontWeight: 400,
-            lineHeight: '42px',
-          }}
-        >
-          Áreas
-        </Typography>
+        <BreadcrumbsComponent
+          prefix={'Gestión'}
+          title={'Áreas'}
+        />
       </Box>
       <Divider />
       <Box

--- a/src/pages/Containers/ContainerPage.jsx
+++ b/src/pages/Containers/ContainerPage.jsx
@@ -8,7 +8,8 @@ import {
 export const ContainerPage = () => {
   return (
     <FilterSideComponent
-      title={'Gestión > Contenedores'}
+      prefix={'Gestión'}
+      title={'Contenedores'}
       component={() => <ContainerContent />}
     />
   );

--- a/src/pages/CreateArea/CreateAreaPage.jsx
+++ b/src/pages/CreateArea/CreateAreaPage.jsx
@@ -15,6 +15,9 @@ import './CreateAreaPage.css';
 import {
   APIProvider 
 } from '@vis.gl/react-google-maps';
+import {
+  BreadcrumbsComponent 
+} from '../../components/BreadcrumbsComponent';
 
 
 
@@ -45,19 +48,16 @@ const CreateAreaPage = () => {
     >
       <Box
         sx={{
-          width: 1,
-          padding: '16px 64px 13px',
+          width: '100%',
+          padding: '16px 32px',
         }}
       >
-        <Typography
-          sx={{
-            fontSize: '34px',
-            fontWeight: 400,
-            lineHeight: '42px',
-          }}
-        >
-          Crear nueva área
-        </Typography>
+        <BreadcrumbsComponent
+          prefix={'Gestión'}
+          title={'Áreas'}
+          subtitle={'Nueva área'}
+          titleLink={'/areas'}
+        />
       </Box>
       <Divider />
       <Box

--- a/src/pages/Empleados/EmployeePage.jsx
+++ b/src/pages/Empleados/EmployeePage.jsx
@@ -8,7 +8,8 @@ import {
 const EmployeePage = () => {
   return (
     <FilterSideComponent
-      title={'Gestión > Empleados'}
+      prefix={'Gestión'}
+      title={'Empleados'}
       component={() => <EmployeeContent />}
     />
   );


### PR DESCRIPTION
Created breadcrumb component, to make it more reusable and added material UI breadcrumb with its NavigateNextIcon which looks better than the ">". 
We have these cases for the breadcrumbs:
- only 1 part. e.g.: "Mapa". not a link, not clickable.
- 2 parts. e.g.: Gestión > Empleados. None of the parts is a link, not clickable.
- 2 parts. e.g.: Reportes > Reporte X. `Reportes `is a clickable link.
- 3 parts. e.g.: Gestión > Areas > Nueva Area. `Areas` is a clickable link.