### PR TITLE
Feature/PF-163-newReportMap

### DIFF
--- a/src/components/InputForm/InputForm.jsx
+++ b/src/components/InputForm/InputForm.jsx
@@ -13,6 +13,7 @@ export const InputForm = ({
   variant = 'outlined',
   size = 'small',
   helperText = null,
+  disabled = false
 }) => {
   return (
     <Controller
@@ -35,6 +36,7 @@ export const InputForm = ({
             label={label}
             {...field}
             helperText={helperText}
+            disabled={disabled}
             sx={{
               '& .MuiInputBase-input:-webkit-autofill': { //added this to prevent weird look when the browser autofills the field
                 '-webkit-box-shadow': '0 0 0 1000px white inset',

--- a/src/components/MapWithContainers/MapWithContainers.jsx
+++ b/src/components/MapWithContainers/MapWithContainers.jsx
@@ -1,0 +1,33 @@
+import {
+  APIProvider, Map
+} from '@vis.gl/react-google-maps';
+
+export const MapWithContainers = ({
+  apiKey, zoom, centerPosition, containers
+}) => {
+  return (
+    <APIProvider
+      apiKey={apiKey}
+    >
+      <Map
+        defaultZoom={zoom}
+        defaultCenter={centerPosition}
+        mapId='658a52589c7a963'
+        streetViewControl={false}
+        mapTypeControl={false}
+        zoomControl={false}
+        gestureHandling={'greedy'}
+        disableDefaultUI={true}
+        id='garbi-home-map'
+        style={{
+          outline: 'none',
+          '&:focus': {
+            outline: 'none',
+          },
+        }}
+      >
+        {containers}
+      </Map>
+    </APIProvider>
+  );
+};

--- a/src/components/MapWithContainers/index.js
+++ b/src/components/MapWithContainers/index.js
@@ -1,0 +1,3 @@
+export {
+  MapWithContainers 
+} from './MapWithContainers';

--- a/src/forms/CreateReport/CreateReportForm.jsx
+++ b/src/forms/CreateReport/CreateReportForm.jsx
@@ -40,60 +40,8 @@ import {
   useContainers
 } from '../../api/hooks/useContainers/useContainers';
 import {
-  APIProvider, AdvancedMarker, Map, useMarkerRef, useMap
+  APIProvider, AdvancedMarker, Map, useMap
 } from '@vis.gl/react-google-maps';
-
-const UserLocationMarker = () => {
-  const map = useMap();
-  const [userLocation, setUserLocation] = useState(null);
-
-  useEffect(() => {
-    if (!map) return;
-
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          const location = {
-            lat: position.coords.latitude,
-            lng: position.coords.longitude,
-          };
-          setUserLocation(location);
-
-          new google.maps.Marker({
-            position: location,
-            map,
-            icon: {
-              path: google.maps.SymbolPath.CIRCLE,
-              fillColor: '#4285F4',
-              fillOpacity: 0.8,
-              strokeColor: 'white',
-              strokeWeight: 2,
-              scale: 8,
-            },
-          });
-
-          new google.maps.Marker({
-            position: location,
-            map,
-            icon: {
-              path: google.maps.SymbolPath.CIRCLE,
-              strokeColor: '#4285F4',
-              strokeOpacity: 0,
-              fillColor: '#4285F4',
-              fillOpacity: 0.1,
-              scale: 15,
-            },
-          });
-        },
-        (error) => {
-          console.error('Error getting location', error);
-        }
-      );
-    }
-  }, [map]);
-
-  return null;
-};
 
 const tipos = [
   {
@@ -223,14 +171,72 @@ export const CreateReportForm = () => {
     }
   };
 
-
   const [containers, setContainers] = useState([]);
   const [containerSelected, setContainerSeleted] = useState(null);
   
-  const position = {
+
+  const [userLocation, setUserLocation] = useState(null);
+  const [mapCenter, setMapCenter] = useState({
     lat: -34.5893,
-    lng: -58.3974,
+    lng: -58.3974 
+  });
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const userLocation = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          };
+          setUserLocation(userLocation);
+          if (mapCenter.lat === -34.5893 && mapCenter.lng === -58.3974) {
+            setMapCenter(userLocation);
+          }
+        },
+        (error) => {
+          console.error('Error getting location: ', error);
+        }
+      );
+    }
+  }, [mapCenter]);
+
+  const UserLocationMarker = () => {
+    const map = useMap();
+  
+    useEffect(() => {
+      if (!map || !userLocation) return;
+  
+      new google.maps.Marker({
+        position: userLocation,
+        map,
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          fillColor: '#4285F4',
+          fillOpacity: 0.8,
+          strokeColor: 'white',
+          strokeWeight: 2,
+          scale: 8,
+        },
+      });
+
+      new google.maps.Marker({
+        position: userLocation,
+        map,
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          strokeColor: '#4285F4',
+          strokeOpacity: 0,
+          fillColor: '#4285F4',
+          fillOpacity: 0.05,
+          scale: 15,
+        },
+      });
+    }, [map, userLocation]);
+  
+    return null;
   };
+
   const {
     getContainers: {
       getContainers: getContainers
@@ -272,10 +278,7 @@ export const CreateReportForm = () => {
     }
   }, []);
 
-  const [userLocation, setUserLocation] = useState({
-    lat: -34.5893,
-    lng: -58.3974 
-  });
+  
   useEffect(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
@@ -291,22 +294,6 @@ export const CreateReportForm = () => {
       );
     }
   }, []);
-
-  const [markerRef, marker] = useMarkerRef();
-  useEffect(() => {
-    if (!marker) {
-      return;
-    }
-
-    // do something with marker instance here
-  }, [marker]);
-
-  const map = useMap();
-  useEffect(() => {
-    if (!map) return;
-
-    // here you can interact with the imperative maps API
-  }, [map]);
 
   const handleContainerClick = (container) => {
     setValue('address', container.address.street +' '+ container.address.number || '');
@@ -506,9 +493,7 @@ export const CreateReportForm = () => {
             >
               <Map
                 defaultZoom={16}
-                //center={userLocation}
-                //center={userLocation || { lat: -34.5893, lng: -58.3974 }}
-                defaultCenter={userLocation || position}//{position}
+                defaultCenter={mapCenter}
                 mapId='658a52589c7a963'
                 streetViewControl={false}
                 mapTypeControl={false}
@@ -549,6 +534,7 @@ export const CreateReportForm = () => {
             label={'Dirección aproximada del contenedor *'}
             variant='filled'
             size='medium'
+            disabled='true'
           />
         </Grid>
         <Grid
@@ -562,6 +548,7 @@ export const CreateReportForm = () => {
             label={'Barrio *'}
             variant='filled'
             size='medium'
+            disabled='true'
           />
         </Grid>
         <Grid
@@ -575,6 +562,7 @@ export const CreateReportForm = () => {
             label={'Identificador del contenedor (6 dígitos)'}
             variant='filled'
             size='medium'
+            disabled='true'
           />
         </Grid>
         <Grid

--- a/src/forms/CreateReport/CreateReportForm.jsx
+++ b/src/forms/CreateReport/CreateReportForm.jsx
@@ -104,75 +104,6 @@ export const CreateReportForm = () => {
 
   const navigate = useNavigate()
 
-  const createReportSchema = object({
-    title: string().required('El titulo es un campo obligatorio'),
-    type: string().required('Debe seleccionar una opcion'),
-    description: string().required('La descripcion es un campo obligatorio'),
-    address: string().required(),
-    neighborhood: string().required(),
-    containerId: string().length(6, 'El identificador del contenedor debe tener 6 caracteres')
-      .optional(),
-    email: string().email('Debe ser un email valido')
-      .required('El mail es un campo obligatorio'),
-    image: mixed(),
-    phone: string()
-  }).required();
-
-  const {
-    control, handleSubmit, setValue, formState: {
-      errors
-    }
-  } = useForm({
-    defaultValues: {
-      title: 'sasA',
-      description: 'dssadsd',
-      type: 'BASURA_EN_LA_CALLE',
-      address: '',
-      neighborhood: '',
-      containerId: '',
-      email: 'sdada@saddad.com',
-      phone: '465456465'
-    },
-    resolver: yupResolver(createReportSchema),
-  });
-
-  const onSubmit = async (data) => {
-
-    const formData = new FormData();
-
-    data.address = [
-      {
-        street: data.address.split(' ')[0],
-        number: data.address.split(' ')[1],
-        neighborhood: data.neighborhood
-      }
-    ];
-
-    const report = {
-      containerId: data.containerId,
-      title: data.title,
-      description: data.description,
-      address: data.address,
-      phone: data.phone,
-      email: data.email,
-      type: data.type
-    };
-
-    formData.append('report', JSON.stringify(report));
-    formData.append('image', selectedFile);
-
-    try {
-      const response = await createReport(formData);  // Envía el FormData al backend
-
-      if (response.success) {
-        navigate('/reportes');
-      }
-    } catch (error) {
-      console.error('Error creating report:', error);
-    }
-  };
-  
-
   const position = {
     lat: -34.5893,
     lng: -58.3974,
@@ -180,6 +111,7 @@ export const CreateReportForm = () => {
 
   const [containers, setContainers] = useState([]);
   const [containerSelected, setContainerSeleted] = useState(null);
+  const [containerError, setContainerError] = useState(false);
 
   const {
     getContainers: {
@@ -226,6 +158,80 @@ export const CreateReportForm = () => {
     setValue('containerId', container._id.slice(-6));
     setContainerSeleted(container);
   };
+
+  const createReportSchema = object({
+    title: string().required('El titulo es un campo obligatorio'),
+    type: string().required('Debe seleccionar una opcion'),
+    description: string().required('La descripcion es un campo obligatorio'),
+    /*address: string().required(),
+    neighborhood: string().required(),
+    containerId: string().length(6, 'El identificador del contenedor debe tener 6 caracteres')
+      .optional(),*/
+    email: string().email('Debe ser un email valido')
+      .required('El mail es un campo obligatorio'),
+    image: mixed(),
+    phone: string()
+  }).required();
+
+  const {
+    control, handleSubmit, setValue, formState: {
+      errors
+    }
+  } = useForm({
+    defaultValues: {
+      title: 'sasA',
+      description: 'dssadsd',
+      type: 'BASURA_EN_LA_CALLE',
+      address: '',
+      neighborhood: '',
+      containerId: '',
+      email: 'sdada@saddad.com',
+      phone: '465456465'
+    },
+    resolver: yupResolver(createReportSchema),
+  });
+
+  const onSubmit = async (data) => {
+    if (!containerSelected) {
+      setContainerError(true);
+      return;
+    }
+    setContainerError(false);
+
+    const formData = new FormData();
+
+    data.address = [
+      {
+        street: data.address.split(' ')[0],
+        number: data.address.split(' ')[1],
+        neighborhood: data.neighborhood
+      }
+    ];
+
+    const report = {
+      containerId: data.containerId,
+      title: data.title,
+      description: data.description,
+      address: data.address,
+      phone: data.phone,
+      email: data.email,
+      type: data.type
+    };
+
+    formData.append('report', JSON.stringify(report));
+    formData.append('image', selectedFile);
+
+    try {
+      const response = await createReport(formData);  // Envía el FormData al backend
+
+      if (response.success) {
+        navigate('/reportes');
+      }
+    } catch (error) {
+      console.error('Error creating report:', error);
+    }
+  };
+  
 
   return (
     <form
@@ -409,10 +415,20 @@ export const CreateReportForm = () => {
           item
           xs={12}
         >
+          <Typography
+            sx={{
+              fontSize: '16px',
+              fontWeight: 400,
+              mt: '24px',
+              mb: '8px',
+              color: 'black',
+            }}
+          >
+            Seleccione el contenedor afectado en el mapa
+          </Typography>
           <Box
             width='100%'
             height='400px'
-            mt='24px'
           >
             <APIProvider
               apiKey={apiKeyGoogleMaps}
@@ -444,6 +460,17 @@ export const CreateReportForm = () => {
               </Map>
             </APIProvider>
           </Box>
+          {containerError && (
+            <Typography
+              sx={{
+                fontSize:'0.85rem',
+                color:'red',
+                mt: 1,
+              }}
+            >
+              Debe seleccionar un contenedor en el mapa.
+            </Typography>
+          )}
         </Grid>
 
         <Grid
@@ -477,6 +504,7 @@ export const CreateReportForm = () => {
         <Grid
           item
           xs={12}
+          mb='16px'
         >
           <InputForm
             name='containerId'

--- a/src/forms/CreateReport/CreateReportForm.jsx
+++ b/src/forms/CreateReport/CreateReportForm.jsx
@@ -40,7 +40,7 @@ import {
   useContainers
 } from '../../api/hooks/useContainers/useContainers';
 import {
-  APIProvider, AdvancedMarker, Map, useMap
+  APIProvider, AdvancedMarker, Map
 } from '@vis.gl/react-google-maps';
 
 const tipos = [
@@ -91,7 +91,8 @@ const HtmlTooltip = styled(({
 }));
 
 export const CreateReportForm = () => {
-  const addressRegex = /^[A-ZÁÉÍÓÚÑ][a-záéíóúñA-ZÁÉÍÓÚÑ\s]*\s\d{1,4}$/;
+  const apiKeyGoogleMaps = import.meta.env.VITE_REACT_APP_API_KEY_GOOGLE_MAPS;
+  //const addressRegex = /^[A-ZÁÉÍÓÚÑ][a-záéíóúñA-ZÁÉÍÓÚÑ\s]*\s\d{1,4}$/;
   const [selectedImage, setSelectedImage] = useState(null);
   const [selectedFile, setSelectedFile] = useState(null);
 
@@ -108,12 +109,12 @@ export const CreateReportForm = () => {
     type: string().required('Debe seleccionar una opcion'),
     description: string().required('La descripcion es un campo obligatorio'),
     address: string().required(),
+    neighborhood: string().required(),
     containerId: string().length(6, 'El identificador del contenedor debe tener 6 caracteres')
       .optional(),
     email: string().email('Debe ser un email valido')
       .required('El mail es un campo obligatorio'),
     image: mixed(),
-    neighborhood: string().required(),
     phone: string()
   }).required();
 
@@ -170,80 +171,21 @@ export const CreateReportForm = () => {
       console.error('Error creating report:', error);
     }
   };
+  
+
+  const position = {
+    lat: -34.5893,
+    lng: -58.3974,
+  };
 
   const [containers, setContainers] = useState([]);
   const [containerSelected, setContainerSeleted] = useState(null);
-  
-
-  const [userLocation, setUserLocation] = useState(null);
-  const [mapCenter, setMapCenter] = useState({
-    lat: -34.5893,
-    lng: -58.3974 
-  });
-
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          const userLocation = {
-            lat: position.coords.latitude,
-            lng: position.coords.longitude,
-          };
-          setUserLocation(userLocation);
-          if (mapCenter.lat === -34.5893 && mapCenter.lng === -58.3974) {
-            setMapCenter(userLocation);
-          }
-        },
-        (error) => {
-          console.error('Error getting location: ', error);
-        }
-      );
-    }
-  }, [mapCenter]);
-
-  const UserLocationMarker = () => {
-    const map = useMap();
-  
-    useEffect(() => {
-      if (!map || !userLocation) return;
-  
-      new google.maps.Marker({
-        position: userLocation,
-        map,
-        icon: {
-          path: google.maps.SymbolPath.CIRCLE,
-          fillColor: '#4285F4',
-          fillOpacity: 0.8,
-          strokeColor: 'white',
-          strokeWeight: 2,
-          scale: 8,
-        },
-      });
-
-      new google.maps.Marker({
-        position: userLocation,
-        map,
-        icon: {
-          path: google.maps.SymbolPath.CIRCLE,
-          strokeColor: '#4285F4',
-          strokeOpacity: 0,
-          fillColor: '#4285F4',
-          fillOpacity: 0.05,
-          scale: 15,
-        },
-      });
-    }, [map, userLocation]);
-  
-    return null;
-  };
 
   const {
     getContainers: {
       getContainers: getContainers
     },
   } = useContainers();
-
-  const apiKeyGoogleMaps = import.meta.env.VITE_REACT_APP_API_KEY_GOOGLE_MAPS;
 
 
   const formatContainers = (containers) => {
@@ -275,23 +217,6 @@ export const CreateReportForm = () => {
       retrieveContainers();
     } catch (e) {
       console.log(e);
-    }
-  }, []);
-
-  
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          setUserLocation({
-            lat: position.coords.latitude,
-            lng: position.coords.longitude,
-          });
-        },
-        (error) => {
-          console.error('Error getting location: ', error);
-        }
-      );
     }
   }, []);
 
@@ -487,13 +412,14 @@ export const CreateReportForm = () => {
           <Box
             width='100%'
             height='400px'
+            mt='24px'
           >
             <APIProvider
               apiKey={apiKeyGoogleMaps}
             >
               <Map
                 defaultZoom={16}
-                defaultCenter={mapCenter}
+                defaultCenter={position}
                 mapId='658a52589c7a963'
                 streetViewControl={false}
                 mapTypeControl={false}
@@ -508,9 +434,6 @@ export const CreateReportForm = () => {
                   },
                 }}
               >
-                {userLocation && (
-                  <UserLocationMarker />
-                )}
                 {containers.map((p) => (
                   <CustomMarker
                     setContainerSeleted={handleContainerClick}
@@ -601,7 +524,8 @@ export const CreateReportForm = () => {
             sx={{
               width: 1,
               display: 'flex',
-              justifyContent: 'center'
+              justifyContent: 'center',
+              mb: '24px'
             }}
           >
             <Button

--- a/src/forms/CreateReport/CreateReportForm.jsx
+++ b/src/forms/CreateReport/CreateReportForm.jsx
@@ -20,6 +20,9 @@ import {
 import {
   InputForm
 } from '../../components/InputForm';
+import {
+  MapWithContainers
+} from '../../components/MapWithContainers';
 import addImage from '/src/assets/mdi_image-plus-outline.svg';
 import {
   yupResolver
@@ -40,7 +43,7 @@ import {
   useContainers
 } from '../../api/hooks/useContainers/useContainers';
 import {
-  APIProvider, AdvancedMarker, Map
+  AdvancedMarker
 } from '@vis.gl/react-google-maps';
 
 const tipos = [
@@ -430,35 +433,18 @@ export const CreateReportForm = () => {
             width='100%'
             height='400px'
           >
-            <APIProvider
-              apiKey={apiKeyGoogleMaps}
-            >
-              <Map
-                defaultZoom={16}
-                defaultCenter={position}
-                mapId='658a52589c7a963'
-                streetViewControl={false}
-                mapTypeControl={false}
-                zoomControl={false}
-                gestureHandling={'greedy'}
-                disableDefaultUI={true}
-                id='garbi-home-map'
-                style={{
-                  outline: 'none',
-                  '&:focus': {
-                    outline: 'none',
-                  },
-                }}
-              >
-                {containers.map((p) => (
-                  <CustomMarker
-                    setContainerSeleted={handleContainerClick}
-                    key={p._id}
-                    point={p}
-                  />
-                ))}
-              </Map>
-            </APIProvider>
+            <MapWithContainers
+              apiKey = {apiKeyGoogleMaps}
+              zoom = {16}
+              centerPosition = {position}
+              containers = {containers.map((p) => (
+                <Marker
+                  setContainerSeleted={handleContainerClick}
+                  key={p._id}
+                  point={p}
+                />
+              ))}
+            />
           </Box>
           {containerError && (
             <Typography
@@ -584,7 +570,7 @@ export const CreateReportForm = () => {
   );
 };
 
-function CustomMarker({
+function Marker({
   point, setContainerSeleted
 }) {
   return (

--- a/src/pages/Home/HomeMainContent.jsx
+++ b/src/pages/Home/HomeMainContent.jsx
@@ -11,8 +11,11 @@ import {
 } from '@mui/material';
 import Button from '@mui/material/Button';
 import {
-  APIProvider, AdvancedMarker, Map
+  AdvancedMarker
 } from '@vis.gl/react-google-maps';
+import {
+  MapWithContainers
+} from '../../components/MapWithContainers';
 import {
   useEffect, useState
 } from 'react';
@@ -233,35 +236,18 @@ export default function HomeMainContent() {
             width={1}
             height={'110%'}
           >
-            <APIProvider
-              apiKey={apiKeyGoogleMaps}
-            >
-              <Map
-                defaultZoom={12}
-                defaultCenter={position}
-                mapId='658a52589c7a963'
-                streetViewControl={false}
-                mapTypeControl={false}
-                zoomControl={false}
-                gestureHandling={'greedy'}
-                disableDefaultUI={true}
-                id='garbi-home-map'
-                style={{
-                  outline: 'none',
-                  '&:focus': {
-                    outline: 'none',
-                  },
-                }}
-              >
-                {containers.map((p) => (
-                  <Marker
-                    setContainerSeleted={setContainerSeleted}
-                    key={p._id}
-                    point={p}
-                  />
-                ))}
-              </Map>
-            </APIProvider>
+            <MapWithContainers
+              apiKey = {apiKeyGoogleMaps}
+              zoom = {12}
+              centerPosition = {position}
+              containers = {containers.map((p) => (
+                <Marker
+                  setContainerSeleted={setContainerSeleted}
+                  key={p._id}
+                  point={p}
+                />
+              ))}
+            />
           </Box>
           {containerSelected && (
             <RightSidePanel


### PR DESCRIPTION
- added map to select container in _Crear Reporte ciudadano_. Behavior is the following: when clicking on a container, the fields below (address, neighbourhood, containerId) are automatically filled with data. Those 3 fields are always disabled, as the BE team request to make things easier for them.
- to do all this, I used a lot of code from the home page
- created MapWithContainers component to use between _Homepage_ and _Crear Reporte ciudadano_..
- I didn't create a component or something for `HtmlTooltip `and `Marker `because they had some differences between _Homepage_ and _Crear Reporte ciudadano_..